### PR TITLE
JW-73 Implement missing functions for ini_parser.c

### DIFF
--- a/utils/ini_parser.c
+++ b/utils/ini_parser.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 
 #include "ini_parser.h"
+#include "vr_utils_temp.h"
 
 #ifdef __GNUC__
 #include <unistd.h>
@@ -159,8 +160,7 @@ read_string(const char *section, const char *key)
 uint32_t
 read_ip(const char *section, const char *key)
 {
-// TODO: JW-73 Implement read_ip for windows platform
-/*    struct in_addr ip;
+    struct in_addr ip;
 
     if (read_value(section, key) == false) {
         return 0;
@@ -168,36 +168,32 @@ read_ip(const char *section, const char *key)
 
     if (inet_pton(AF_INET, value, &ip) == 1) {
         return ntohl(ip.s_addr);
-    } */
+    }
     return 0;
 }
 
 int
 get_domain()
 {
-	// TODO: JW-73 Implement get_domain for windows platform
-	/**
     const char *platform = read_string(DEFAULT_SECTION, PLATFORM_KEY);
     if (platform &&
        (strcmp(platform, PLATFORM_DPDK) == 0 ||
         strcmp(platform, PLATFORM_NIC) == 0)) {
         return AF_INET;
-    } */
-	return -1337;//AF_NETLINK;
+    }
+        return AF_NETLINK;
 }
 
 int
 get_type()
 {
-	// TODO: JW-73 Implement get_typ for windows platform
-	/*
     const char *platform = read_string(DEFAULT_SECTION, PLATFORM_KEY);
     if (platform &&
         (strcmp(platform, PLATFORM_DPDK) == 0 ||
          strcmp(platform, PLATFORM_NIC) == 0)) {
         return SOCK_STREAM;
-    }*/
-	return -1337; // SOCK_DGRAM;
+    }
+	return SOCK_DGRAM;
 }
 
 uint16_t
@@ -221,15 +217,13 @@ get_ip()
 int
 get_protocol()
 {
-	// TODO: JW-73 Implement get_protocol for windows platform
-	/*
     const char *platform = read_string(DEFAULT_SECTION, PLATFORM_KEY);
     if (platform &&
         (strcmp(platform, PLATFORM_DPDK) == 0 ||
          strcmp(platform, PLATFORM_NIC) == 0)) {
         return 0;
-    } */
-	return -1337; // NETLINK_GENERIC;
+    }
+	return NETLINK_GENERIC;
 }
 
 int

--- a/windows/include/vr_utils_temp.h
+++ b/windows/include/vr_utils_temp.h
@@ -2,11 +2,30 @@
 
 #include "vr_os.h"
 
-// TODO: Remove unused defines and structures
-#define INET6_ADDRSTRLEN 46
+#include <Ws2tcpip.h>
+#include <basetsd.h>
+
+typedef INT8 int8_t;
+typedef UINT8 uint8_t;
+typedef INT16 int16_t;
+typedef UINT16 uint16_t;
+typedef INT32 int32_t;
+typedef UINT32 uint32_t;
+typedef INT64 int64_t;
+typedef UINT64 uint64_t;
+
 #define IFNAMSIZ 16
 #define AF_BRIDGE 7
+// netlink doesn't exist on windows platform
+#define AF_NETLINK 0
+#define NETLINK_GENERIC 0
 
+#define __attribute__packed__open__ __pragma( pack( push, 1 ) )
+#define __attribute__packed__close__ __pragma( pack( pop ) )
+#define __attribute__format__open__(...) /* do nothing */
+#define __attribute__format__close__(...) /* do nothing */
+
+// TODO: Remove unused defines and structures
 #define __attribute__(A) /* do nothing */
 
 #define NLM_F_REQUEST           1       /* It is request message.       */


### PR DESCRIPTION
  Remove TODOs:
   * utils/ini_parser.c:162:// TODO: Implement read_ip for windows platform
   * utils/ini_parser.c:178: // TODO: Implement get_domain for windows platform
   * utils/ini_parser.c:192: // TODO: Implement get_typ for windows platform
   * utils/ini_parser.c:224: // TODO: Implement get_protocol for windows platform