### PR TITLE
NDIS strings to C string in vr_assoc

### DIFF
--- a/include/vr_windows.h
+++ b/include/vr_windows.h
@@ -19,6 +19,9 @@ extern "C" {
 #define VR_INIT_ASSOC_OK        0
 #define VR_INIT_ASSOC_FAILED    1
 
+#define VR_ASSOC_STRING_MAX_LEN 63
+#define VR_ASSOC_STRING_SIZE    (VR_ASSOC_STRING_MAX_LEN + 1)
+
 struct vr_interface; // Forward declaration
 
 struct vr_packet;
@@ -44,14 +47,15 @@ struct vr_assoc {
     struct vr_interface* interface;
     struct vr_assoc* next;
 
-    NDIS_IF_COUNTED_STRING string;
+    char string[VR_ASSOC_STRING_SIZE];
     struct {
         NDIS_SWITCH_PORT_ID port_id;
         NDIS_SWITCH_NIC_INDEX nic_index;
     };
 };
 
-NDIS_IF_COUNTED_STRING vr_get_name_from_friendly_name(const NDIS_IF_COUNTED_STRING friendly);
+/* Extracts interface name from provided friendly name and stores it in provided `name` buffer. */
+NDIS_STATUS vr_get_name_from_friendly_name(NDIS_IF_COUNTED_STRING friendly, char *name, size_t name_buffer_size);
 
 struct nlattr {
     UINT16           nla_len;
@@ -72,9 +76,11 @@ struct genlmsghdr {
     UINT16   reserved;
 };
 
-struct vr_assoc* vr_get_assoc_name(const NDIS_IF_COUNTED_STRING string);
-void vr_set_assoc_oid_name(const NDIS_IF_COUNTED_STRING interface_name, struct vr_interface* interface);
-void vr_delete_assoc_name(const NDIS_IF_COUNTED_STRING interface_name);
+NDIS_STATUS vr_assoc_set_string(struct vr_assoc *entry, const char* new_assoc_string);
+
+struct vr_assoc* vr_get_assoc_by_name(const char *interface_name);
+void vr_set_assoc_by_name(const char *interface_name, struct vr_interface* interface);
+void vr_delete_assoc_by_name(const char *interface_name);
 
 struct vr_assoc* vr_get_assoc_ids(const NDIS_SWITCH_PORT_ID port_id, const NDIS_SWITCH_NIC_INDEX nic_index);
 void vr_set_assoc_oid_ids(const NDIS_SWITCH_PORT_ID port_id, const NDIS_SWITCH_NIC_INDEX nic_index, struct vr_interface* interface);

--- a/include/vr_windows.h
+++ b/include/vr_windows.h
@@ -76,7 +76,7 @@ struct genlmsghdr {
     UINT16   reserved;
 };
 
-NDIS_STATUS vr_assoc_set_string(struct vr_assoc *entry, const char* new_assoc_string);
+NTSTATUS vr_assoc_set_string(struct vr_assoc *entry, const char* new_assoc_string);
 
 struct vr_assoc* vr_get_assoc_by_name(const char *interface_name);
 void vr_set_assoc_by_name(const char *interface_name, struct vr_interface* interface);

--- a/windows/precomp.h
+++ b/windows/precomp.h
@@ -3,6 +3,7 @@
 #include <netiodef.h>
 #include <intsafe.h>
 #include <ntintsafe.h>
+#include <Ntstrsafe.h>
 
 #include "vr_windows.h"
 #include "vr_interface.h"

--- a/windows/vr_assoc.c
+++ b/windows/vr_assoc.c
@@ -5,16 +5,17 @@ NDIS_RW_LOCK_EX* name_lock;
 NDIS_RW_LOCK_EX* ids_lock;
 
 #define MAP_SIZE 512
+#define HASH_ERROR ((unsigned int)(-1))
 
 struct criteria {
-    NDIS_IF_COUNTED_STRING name;
+    const char *name;
     NDIS_SWITCH_PORT_ID port_id;
     NDIS_SWITCH_NIC_INDEX nic_index;
 };
 
 typedef void (*setterFunc)(struct vr_assoc*, const struct criteria*);
 typedef BOOLEAN (*compareFunc)(struct vr_assoc*, const struct criteria*);
-typedef int (*hashFunc)(const struct criteria*);
+typedef unsigned int (*hashFunc)(const struct criteria*);
 
 /*
  * A generated map of chars.
@@ -44,28 +45,71 @@ const static unsigned char char_map[256] = {
 static struct vr_assoc* name_map[MAP_SIZE];
 static struct vr_assoc* ids_map[MAP_SIZE];
 
-NDIS_IF_COUNTED_STRING vr_get_name_from_friendly_name(const NDIS_IF_COUNTED_STRING friendly)
+NDIS_STATUS vr_get_name_from_friendly_name(
+    NDIS_IF_COUNTED_STRING friendly,
+    char *name,
+    size_t name_buffer_size)
 {
-    NDIS_IF_COUNTED_STRING ret;
+    // Ensure that string in `friendly` is null-terminated
+    unsigned int pos_past_end = friendly.Length;
+    if (pos_past_end >= IF_MAX_STRING_SIZE + 1) {
+        return NDIS_STATUS_FAILURE;
+    }
+    friendly.String[pos_past_end] = '\0';
 
-    int i = friendly.Length;
+    UNICODE_STRING friendly_unicode_str;
+    ANSI_STRING friendly_ansi_str;
+    NTSTATUS status;
+
+    RtlUnicodeStringInit(&friendly_unicode_str, friendly.String);
+    status = RtlUnicodeStringToAnsiString(&friendly_ansi_str, &friendly_unicode_str, TRUE);
+    if (status != STATUS_SUCCESS) {
+        return NDIS_STATUS_FAILURE;
+    }
+
+    int i = friendly_ansi_str.Length;
     // The names are in format of "Container Port a30f213f"
     // To be the most accurate, get the last "word", speparated by a space
-    while (friendly.String[--i] != L' ')
-        if (i == 0) // Name is not conforming to our standards, must be not a container port
-        {
-            ret.Length = 0;
-            return ret;
+    while (friendly_ansi_str.Buffer[--i] != ' ') {
+        if (i == 0) {
+            // Name is not conforming to our standards, must be not a container port
+            return NDIS_STATUS_FAILURE;
         }
+    }
 
-    wcscpy_s(ret.String, friendly.Length - i + 1, friendly.String + i + 1);
-    ret.Length = (USHORT)(friendly.Length - i + 1);
+    PCHAR src = friendly_ansi_str.Buffer + i + 1;
+    size_t src_max_bytes = friendly_ansi_str.Length - i - 1;
+    status = RtlStringCbCopyNA(name, name_buffer_size, src, src_max_bytes);
+    if (status != STATUS_SUCCESS) {
+        return NDIS_STATUS_FAILURE;
+    }
 
-    return ret;
+    RtlFreeAnsiString(&friendly_ansi_str);
+
+    return NDIS_STATUS_SUCCESS;
+}
+
+NDIS_STATUS vr_assoc_set_string(struct vr_assoc *entry, const char* new_assoc_string)
+{
+    if (entry == NULL || new_assoc_string == NULL) {
+        return NDIS_STATUS_FAILURE;
+    }
+
+    NTSTATUS copy_status = RtlStringCbCopyA(entry->string, sizeof(entry->string), new_assoc_string);
+    if (NT_SUCCESS(copy_status)) {
+        return NDIS_STATUS_SUCCESS;
+    } else {
+        return NDIS_STATUS_FAILURE;
+    }
 }
 
 struct vr_assoc* vr_get_assoc(struct vr_assoc** map, setterFunc setter, hashFunc hash, compareFunc cmp, const struct criteria* params)
 {
+    unsigned int calculated_hash = hash(params);
+    if (calculated_hash >= MAP_SIZE) {
+        return NULL;
+    }
+
     struct vr_assoc** field = map + hash(params);
 
     while (*field != NULL)
@@ -111,21 +155,24 @@ void vr_delete_assoc(struct vr_assoc** map, hashFunc hash, compareFunc cmp, cons
 static void setter_name(struct vr_assoc* entry, const struct criteria* params)
 {
     if (entry) {
-        entry->string = params->name;
+        vr_assoc_set_string(entry, params->name);
         entry->nic_index = 0;
         entry->port_id = 0;
     }
 }
 
-static int hash_name(const struct criteria* params)
+static unsigned int hash_name(const struct criteria* params)
 {
-    int hash = 0;
-    int i = params->name.Length;
-    const WCHAR* str = params->name.String;
+    size_t name_length;
+    NTSTATUS name_length_status = RtlStringCbLengthA(params->name, VR_ASSOC_STRING_SIZE, &name_length);
+    if (!NT_SUCCESS(name_length_status)) {
+        return HASH_ERROR;
+    }
 
-    while (i-- != 0)
-    {
-        hash ^= char_map[(*str++) % 256] * 5;
+    int hash = 0;
+    int i = 0;
+    for (i = 0; i < name_length; ++i) {
+        hash ^= char_map[(params->name[i]) % 256] * 5;
     }
 
     return hash;
@@ -133,10 +180,24 @@ static int hash_name(const struct criteria* params)
 
 static BOOLEAN cmp_name(struct vr_assoc* entry, const struct criteria* params)
 {
-    return (entry->string.Length == params->name.Length && wcsncmp(entry->string.String, params->name.String, params->name.Length) == 0);
+    NTSTATUS status;
+
+    size_t entry_string_length;
+    status = RtlStringCbLengthA(entry->string, VR_ASSOC_STRING_SIZE, &entry_string_length);
+    if (!NT_SUCCESS(status)) {
+        return FALSE;
+    }
+
+    size_t params_name_length;
+    status = RtlStringCbLengthA(params->name, VR_ASSOC_STRING_SIZE, &params_name_length);
+    if (!NT_SUCCESS(status)) {
+        return FALSE;
+    }
+
+    return entry_string_length == params_name_length && !strncmp(entry->string, params->name, VR_ASSOC_STRING_MAX_LEN);
 }
 
-struct vr_assoc* vr_get_assoc_name(const NDIS_IF_COUNTED_STRING interface_name)
+struct vr_assoc* vr_get_assoc_by_name(const char *interface_name)
 {
     struct criteria params;
     params.name = interface_name;
@@ -145,15 +206,13 @@ struct vr_assoc* vr_get_assoc_name(const NDIS_IF_COUNTED_STRING interface_name)
 
     // This is because the requested element can be lazy-created
     NdisAcquireRWLockWrite(name_lock, &lock, 0);
-
     struct vr_assoc* ret = vr_get_assoc(name_map, setter_name, hash_name, cmp_name, &params);
-
     NdisReleaseRWLock(name_lock, &lock);
 
     return ret;
 }
 
-void vr_set_assoc_oid_name(const NDIS_IF_COUNTED_STRING interface_name, struct vr_interface* interface)
+void vr_set_assoc_by_name(const char *interface_name, struct vr_interface* interface)
 {
     struct criteria params;
     params.name = interface_name;
@@ -174,7 +233,7 @@ void vr_set_assoc_oid_name(const NDIS_IF_COUNTED_STRING interface_name, struct v
     return;
 }
 
-void vr_delete_assoc_name(const NDIS_IF_COUNTED_STRING interface_name)
+void vr_delete_assoc_by_name(const char *interface_name)
 {
     struct criteria params;
     params.name = interface_name;
@@ -193,10 +252,11 @@ static void setter_ids(struct vr_assoc* entry, const struct criteria* params)
     if (entry) {
         entry->nic_index = params->nic_index;
         entry->port_id = params->port_id;
+        entry->interface = NULL;
     }
 }
 
-static int hash_ids(const struct criteria* params)
+static unsigned int hash_ids(const struct criteria* params)
 {
     int hash = (params->port_id + params->nic_index) % MAP_SIZE; //NIC is almost always 0 and port grows incrementally, so this should be a pretty good hash
 

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -898,18 +898,7 @@ win_soft_reset(struct vrouter *router)
 void
 win_register_nic(struct vr_interface* vif)
 {
-    NDIS_IF_COUNTED_STRING interface_name;
-    ANSI_STRING ansi_string;
-    NDIS_STRING unicode_string;
-
-    RtlInitAnsiString(&ansi_string, (char*) vif->vif_name);
-    RtlAnsiStringToUnicodeString(&unicode_string, &ansi_string, TRUE);
-    RtlCopyMemory(interface_name.String, unicode_string.Buffer, unicode_string.Length);
-    interface_name.Length = unicode_string.Length;
-
-    RtlFreeUnicodeString(&unicode_string);
-
-    struct vr_assoc* assoc = vr_get_assoc_name(interface_name);
+    struct vr_assoc* assoc = vr_get_assoc_by_name(vif->vif_name);
     assoc->interface = vif;
 
     if (assoc->port_id != 0 || assoc->nic_index != 0) { // There was already an oid request so you can get port_id, nic_index in the assoc field, so both name_map and ids_map should be updated

--- a/windows/vrouter_mod.c
+++ b/windows/vrouter_mod.c
@@ -133,19 +133,21 @@ AddNicToArray(struct vr_switch_context* ctx, struct vr_nic* nic, NDIS_IF_COUNTED
     }
     ctx->nics[ctx->num_nics++] = *nic;
 
-    NDIS_IF_COUNTED_STRING _name = vr_get_name_from_friendly_name(name);
+    if (nic->nic_type == NdisSwitchNicTypeInternal) {
+        char nic_name[VR_ASSOC_STRING_SIZE] = { 0 };
+        NDIS_STATUS status = vr_get_name_from_friendly_name(name, nic_name, sizeof(nic_name));
+        if (status != NDIS_STATUS_SUCCESS) {
+            return NDIS_STATUS_FAILURE;
+        }
 
-    if (nic->nic_type == NdisSwitchNicTypeInternal &&
-        name.Length != 0) // We've got a container, because vr_get_name_from_friendly_name returned us the container name
-    {
-        struct vr_assoc* assoc_by_name = vr_get_assoc_name(_name);
+        struct vr_assoc* assoc_by_name = vr_get_assoc_by_name(nic_name);
         struct vr_assoc* assoc_by_ids = vr_get_assoc_ids(nic->port_id, nic->nic_index);
         if (assoc_by_name != NULL && assoc_by_ids != NULL) {
             assoc_by_name->port_id = nic->port_id;
             assoc_by_name->nic_index = nic->nic_index;
             struct vr_interface* interface = assoc_by_name->interface;
 
-            assoc_by_ids->string = _name;
+            vr_assoc_set_string(assoc_by_ids, nic_name);
             assoc_by_ids->interface = interface; // This will do nothing if dp-core didn't create an interface yet, because it will be NULL
         } else {
             return NDIS_STATUS_RESOURCES;
@@ -445,8 +447,15 @@ SxExtDisconnectNic(
         }
     }
 
-    vr_delete_assoc_name(Nic->NicFriendlyName);
+    /* Delete vr_assoc entry referring to this NIC in ids_map */
     vr_delete_assoc_ids(Nic->PortId, Nic->NicIndex);
+
+    /* Delete vr_assoc entry referring to this NIC in name_map */
+    char nic_name[VR_ASSOC_STRING_SIZE] = { 0 };
+    NDIS_STATUS status = vr_get_name_from_friendly_name(Nic->NicFriendlyName, nic_name, sizeof(nic_name));
+    if (status == NDIS_STATUS_SUCCESS) {
+        vr_delete_assoc_by_name(nic_name);
+    }
 }
 
 VOID

--- a/windows/vrouter_mod.c
+++ b/windows/vrouter_mod.c
@@ -143,11 +143,15 @@ AddNicToArray(struct vr_switch_context* ctx, struct vr_nic* nic, NDIS_IF_COUNTED
         struct vr_assoc* assoc_by_name = vr_get_assoc_by_name(nic_name);
         struct vr_assoc* assoc_by_ids = vr_get_assoc_ids(nic->port_id, nic->nic_index);
         if (assoc_by_name != NULL && assoc_by_ids != NULL) {
+            NTSTATUS status_set = vr_assoc_set_string(assoc_by_ids, nic_name);
+            if (!NT_SUCCESS(status_set)) {
+                return NDIS_STATUS_FAILURE;
+            }
+
+            struct vr_interface* interface = assoc_by_name->interface;
             assoc_by_name->port_id = nic->port_id;
             assoc_by_name->nic_index = nic->nic_index;
-            struct vr_interface* interface = assoc_by_name->interface;
 
-            vr_assoc_set_string(assoc_by_ids, nic_name);
             assoc_by_ids->interface = interface; // This will do nothing if dp-core didn't create an interface yet, because it will be NULL
         } else {
             return NDIS_STATUS_RESOURCES;


### PR DESCRIPTION
Reimplemented string handling in vr_assoc functions and NIC
connect/disconnect callbacks.

- Removed dependency on NDIS_IF_COUNTED_STRING
  which is based on wchar and replaced it with standard C string.
- Change is introduced because internally dp-core handles on standard C strings
  (e.g. for vif names).