### PR TITLE
JW-322 Incorrect size of allocated memory by vr_btable_attach

### DIFF
--- a/dp-core/vr_btable.c
+++ b/dp-core/vr_btable.c
@@ -189,7 +189,7 @@ vr_btable_attach(struct iovec *iov, unsigned int iov_len,
     if (iov[0].iov_len % esize)
         return NULL;
 
-    alloc_size = sizeof(struct vr_btable *);
+    alloc_size = sizeof(struct vr_btable);
     alloc_size += (sizeof(void *) * iov_len);
     alloc_size += (sizeof(struct vr_btable_partition) * iov_len);
 


### PR DESCRIPTION
The function vr_btable_attach is calculating size of memory, which will be
allocated by dp-core. The one of elements of this sum is size of
vr_btable. Unfortunately the function is using size of pointer to
vr_btable - which is smaller then size of vr_btable.