### PR TITLE
JW-320: Introduces sandesh callbacks in utils

### DIFF
--- a/include/nl_util.h
+++ b/include/nl_util.h
@@ -72,6 +72,24 @@ struct genl_ctrl_message {
 #define NLA_LEN(nla)                    (nla->nla_len - NLA_HDRLEN)
 #define GENLMSG_DATA(buf)               ((char *)buf + GENL_HDRLEN)
 
+struct nl_sandesh_callbacks {
+    void (*vrouter_ops_process)(void *);
+    void (*vr_flow_req_process)(void *);
+    void (*vr_route_req_process)(void *);
+    void (*vr_interface_req_process)(void *);
+    void (*vr_mpls_req_process)(void *);
+    void (*vr_mirror_req_process)(void *);
+    void (*vr_response_process)(void *);
+    void (*vr_nexthop_req_process)(void *);
+    void (*vr_vrf_assign_req_process)(void *);
+    void (*vr_vrf_stats_req_process)(void *);
+    void (*vr_drop_stats_req_process)(void *);
+    void (*vr_vxlan_req_process)(void *);
+    void (*vr_mem_stats_req_process)(void *);
+    void (*vr_fc_map_req_process)(void *);
+    void (*vr_qos_map_req_process)(void *);
+};
+
 /* Suppress NetLink error messages */
 extern bool vr_ignore_nl_errors;
 

--- a/utils/flow.c
+++ b/utils/flow.c
@@ -134,8 +134,32 @@ static void flow_dump_nexthop(vr_nexthop_req *, vr_interface_req *,
 static vr_nexthop_req *flow_get_nexthop(int);
 static int flow_table_map(vr_flow_req *);
 
+void fl_flow_req_process(void *sreq);
+void fl_interface_req_process(void *sreq);
+void fl_response_process(void *sresp);
+void fl_nexthop_req_process(void *sreq);
+void fl_drop_stats_req_process(void *sreq);
+
+struct nl_sandesh_callbacks nl_cb = {
+    .vrouter_ops_process = NULL,
+    .vr_flow_req_process = fl_flow_req_process,
+    .vr_route_req_process = NULL,
+    .vr_interface_req_process = fl_interface_req_process,
+    .vr_mpls_req_process = NULL,
+    .vr_mirror_req_process = NULL,
+    .vr_response_process = fl_response_process,
+    .vr_nexthop_req_process = fl_nexthop_req_process,
+    .vr_vrf_assign_req_process = NULL,
+    .vr_vrf_stats_req_process = NULL,
+    .vr_drop_stats_req_process = fl_drop_stats_req_process,
+    .vr_vxlan_req_process = NULL,
+    .vr_mem_stats_req_process = NULL,
+    .vr_fc_map_req_process = NULL,
+    .vr_qos_map_req_process = NULL,
+};
+
 void
-vr_response_process(void *sresp)
+fl_response_process(void *sresp)
 {
     vr_response *resp = (vr_response *)sresp;
 
@@ -146,7 +170,7 @@ vr_response_process(void *sresp)
 }
 
 void
-vr_flow_req_process(void *sreq)
+fl_flow_req_process(void *sreq)
 {
     vr_flow_req *req = (vr_flow_req *)sreq;
 
@@ -165,7 +189,7 @@ vr_flow_req_process(void *sreq)
 }
 
 void
-vr_interface_req_process(void *arg)
+fl_interface_req_process(void *arg)
 {
     vr_interface_req *req = (vr_interface_req *)arg;
 
@@ -175,7 +199,7 @@ vr_interface_req_process(void *arg)
 }
 
 void
-vr_nexthop_req_process(void *arg)
+fl_nexthop_req_process(void *arg)
 {
     vr_nexthop_req *req = (vr_nexthop_req *)arg;
 
@@ -185,7 +209,7 @@ vr_nexthop_req_process(void *arg)
 }
 
 void
-vr_route_req_process(void *arg)
+fl_route_req_process(void *arg)
 {
     vr_route_req *req = (vr_route_req *)arg;
 
@@ -195,7 +219,7 @@ vr_route_req_process(void *arg)
 }
 
 void
-vr_drop_stats_req_process(void *arg)
+fl_drop_stats_req_process(void *arg)
 {
     vr_drop_stats_req *req = (vr_drop_stats_req *)arg;
 

--- a/utils/nh.c
+++ b/utils/nh.c
@@ -48,6 +48,27 @@ static int comp_nh_ind = 0, lbl_ind = 0;
 static struct in_addr sip, dip;
 static struct nl_client *cl;
 
+void nh_response_process(void *s);
+void nh_nexthop_req_process(void *s_req);
+
+struct nl_sandesh_callbacks nl_cb = {
+    .vrouter_ops_process = NULL,
+    .vr_flow_req_process = NULL,
+    .vr_route_req_process = NULL,
+    .vr_interface_req_process = NULL,
+    .vr_mpls_req_process = NULL,
+    .vr_mirror_req_process = NULL,
+    .vr_response_process = nh_response_process,
+    .vr_nexthop_req_process = nh_nexthop_req_process,
+    .vr_vrf_assign_req_process = NULL,
+    .vr_vrf_stats_req_process = NULL,
+    .vr_drop_stats_req_process = NULL,
+    .vr_vxlan_req_process = NULL,
+    .vr_mem_stats_req_process = NULL,
+    .vr_fc_map_req_process = NULL,
+    .vr_qos_map_req_process = NULL,
+};
+
 static int
 vr_nh_op(struct nl_client *cl, int command, int type, uint32_t nh_id,
         uint32_t if_id, uint32_t vrf_id, int8_t *dst, int8_t  *src,
@@ -200,7 +221,7 @@ nh_print_newline_header(void)
 }
 
 void
-vr_nexthop_req_process(void *s_req)
+nh_nexthop_req_process(void *s_req)
 {
     unsigned int i, printed = 0;
     struct in_addr a;
@@ -306,7 +327,7 @@ vr_nexthop_req_process(void *s_req)
 }
 
 void
-vr_response_process(void *s)
+nh_response_process(void *s)
 {
     vr_response_common_process((vr_response *)s, &dump_pending);
     return;
@@ -760,7 +781,6 @@ validate_options(void)
 
     return;
 }
-
 
 int
 main(int argc, char *argv[])

--- a/utils/nl_util.c
+++ b/utils/nl_util.c
@@ -40,115 +40,126 @@
 
 extern struct nl_response *nl_parse_gen(struct nl_client *);
 
-extern void vrouter_ops_process (void *a) __attribute__((weak));
-extern void vr_flow_req_process(void *s_req) __attribute__((weak));
-extern void vr_route_req_process(void *s_req) __attribute__((weak));
-extern void vr_interface_req_process(void *s_req) __attribute__((weak));
-extern void vr_mpls_req_process(void *s_req) __attribute__((weak));
-extern void vr_mirror_req_process(void *s_req) __attribute__((weak));
-extern void vr_response_process(void *s_req) __attribute__((weak));
-extern void vr_nexthop_req_process(void *s_req) __attribute__((weak));
-extern void vr_vrf_assign_req_process(void *s_req) __attribute__((weak));
-extern void vr_vrf_stats_req_process(void *s_req) __attribute__((weak));
-extern void vr_drop_stats_req_process(void *s_req) __attribute__((weak));
-extern void vr_vxlan_req_process(void *s_req) __attribute__((weak));
-extern void vr_mem_stats_req_process(void *s_req) __attribute__((weak));
-extern void vr_fc_map_req_process(void *s_req) __attribute__((weak));
-extern void vr_qos_map_req_process(void *s_req) __attribute__((weak));
+extern struct nl_sandesh_callbacks nl_cb;
 
-#if defined(_NH)
-void 
-vr_interface_req_process(void *s_req)
-{
-    return;
-}
-
-void 
-vr_route_req_process(void *s_req)
-{
-    return;
-}
-
-void 
-vr_flow_req_process(void *s_req)
-{
-    return;
-}
-
-void 
-vr_drop_stats_req_process(void *s_req)
-{
-    return;
-}
-#endif
 void
 vrouter_ops_process(void *s_req)
 {
-    return;
+    if (nl_cb.vrouter_ops_process) {
+        nl_cb.vrouter_ops_process(s_req);
+    }
 }
 
-#ifndef _WINDOWS
 void
 vr_nexthop_req_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_nexthop_req_process) {
+        nl_cb.vr_nexthop_req_process(s_req);
+    }
 }
-#endif
+
+void
+vr_flow_req_process(void *s_req)
+{
+    if (nl_cb.vr_flow_req_process) {
+        nl_cb.vr_flow_req_process(s_req);
+    }
+}
+
+void
+vr_route_req_process(void *s_req)
+{
+    if (nl_cb.vr_route_req_process) {
+        nl_cb.vr_route_req_process(s_req);
+    }
+}
+
+void
+vr_interface_req_process(void *s_req)
+{
+    if (nl_cb.vr_interface_req_process) {
+        nl_cb.vr_interface_req_process(s_req);
+    }
+}
 
 void
 vr_mpls_req_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_mpls_req_process) {
+        nl_cb.vr_mpls_req_process(s_req);
+    }
 }
 
 void
 vr_mirror_req_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_mirror_req_process) {
+        nl_cb.vr_mirror_req_process(s_req);
+    }
 }
 
-#ifndef _WINDOWS
 void
 vr_response_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_response_process) {
+        nl_cb.vr_response_process(s_req);
+    }
 }
-#endif
 
 void
 vr_vrf_assign_req_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_vrf_assign_req_process) {
+        nl_cb.vr_vrf_assign_req_process(s_req);
+    }
 }
 
 void
 vr_vrf_stats_req_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_vrf_stats_req_process) {
+        nl_cb.vr_vrf_stats_req_process(s_req);
+    }
+}
+
+void
+vr_drop_stats_req_process(void *s_req)
+{
+    if (nl_cb.vr_drop_stats_req_process) {
+        nl_cb.vr_drop_stats_req_process(s_req);
+    }
 }
 
 void
 vr_vxlan_req_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_vxlan_req_process) {
+        nl_cb.vr_vxlan_req_process(s_req);
+    }
 }
 
 void
 vr_mem_stats_req_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_mem_stats_req_process) {
+        nl_cb.vr_mem_stats_req_process(s_req);
+    }
 }
 
 void
 vr_qos_map_req_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_qos_map_req_process) {
+        nl_cb.vr_qos_map_req_process(s_req);
+    }
 }
 
 void
 vr_fc_map_req_process(void *s_req)
 {
-    return;
+    if (nl_cb.vr_fc_map_req_process) {
+        nl_cb.vr_fc_map_req_process(s_req);
+    }
 }
 
 struct nl_response *

--- a/utils/utils.vcxproj
+++ b/utils/utils.vcxproj
@@ -137,6 +137,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;_NH;%(PreprocessorDefinitions);_WINDOWS</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\tools\sandesh\library\c\;..\windows\sandesh-temp\;..\windows\include\;..\windows\;..\include;..\..\tools\</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/utils/utils.vcxproj
+++ b/utils/utils.vcxproj
@@ -135,7 +135,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_NH;%(PreprocessorDefinitions);_WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINDOWS</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\tools\sandesh\library\c\;..\windows\sandesh-temp\;..\windows\include\;..\windows\;..\include;..\..\tools\</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
@@ -170,7 +170,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_NH;%(PreprocessorDefinitions);_WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_WINDOWS</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\tools\sandesh\library\c\;..\windows\sandesh-temp\;..\windows\include\;..\windows\;..\include;..\..\tools\</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/utils/win/flow/flow.vcxproj
+++ b/utils/win/flow/flow.vcxproj
@@ -122,6 +122,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\..\tools\;..\..\..\windows\include;..\..\..\include\;..\..\..\windows\sandesh-temp\;..\..\..\..\tools\sandesh\library\c;</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/vRouter.vcxproj
+++ b/vRouter.vcxproj
@@ -142,6 +142,7 @@
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <OutputName>ndislwf</OutputName>
     <IncludePath>$(ProjectDir)\Include;$(IncludePath)</IncludePath>
+    <ApiValidator_Enable>false</ApiValidator_Enable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>


### PR DESCRIPTION
Linux/FreeBSD versions of Contrail utils use GCC's weak symbols, which
are not supported by MSVC. This causes linker errors due to duplicate
function definitions of sandesh callbacks, e.g. vr_nexthop_req_process.
One of the definitions is in utils/nl_util.c and other one is in
corresponding utility file, e.g. utils/nh.c).

nl_sandesh_callbacks struct is introduced to solve this issue. Every
utility should provide a set of pointers to required sandesh callbacks,
write those function pointers in nl_sandesh_callbacks struct and export
it as `nl_cb`.

Other changes:

* `<RuntimeLibrary>MultiThreaded</RuntimeLibrary>` change causes Debug builds of utils to statically link against MS Visual libraries, so they are not needed on the machine where utils are run.

* `<ApiValidator_Enable>false</ApiValidator_Enable>` fixes issue with extension compilation. If extension compilation is run after building utility, then user-space api validator is run on extension build. Aforementioned setting disables api validator check in vRouter project.