### PR TITLE
JW-593: Use preallocated buffers for vr_packet

### DIFF
--- a/include/vr_packet.h
+++ b/include/vr_packet.h
@@ -269,6 +269,9 @@ struct vr_packet {
 #ifdef _WINDOWS
     void* vp_net_buffer_list;
     unsigned char vp_win_flags;
+
+    unsigned short vp_win_data;
+    ULONG vp_win_data_tag; /* Allocation tag used when vr_packet is CREATED */
 #endif
 };
 

--- a/include/vr_windows.h
+++ b/include/vr_windows.h
@@ -105,7 +105,9 @@ void win_set_physical(struct vr_assoc* assoc);
 
 extern struct host_os windows_host;
 
-extern void win_pfree_unaccounted(struct vr_packet *pkt);
+extern struct vr_packet *win_allocate_packet(void *buffer, unsigned int size, ULONG allocation_tag);
+extern void win_free_packet(struct vr_packet *pkt);
+
 extern void win_if_lock(void);
 extern void win_if_unlock(void);
 

--- a/windows/vr_host_interface.c
+++ b/windows/vr_host_interface.c
@@ -77,7 +77,7 @@ __win_if_tx(struct vr_interface *vif, struct vr_packet *pkt)
 
     NDIS_SWITCH_PORT_DESTINATION newDestination = { 0 };
 
-    if (pkt->vp_win_data > 0) {
+    if ((pkt->vp_win_flags & VP_WIN_CREATED) && pkt->vp_win_data > 0) {
         NdisAdvanceNetBufferListDataStart(nbl, pkt->vp_win_data, FALSE, NULL);
         pkt->vp_win_data = 0;
     }

--- a/windows/vr_host_interface.c
+++ b/windows/vr_host_interface.c
@@ -77,6 +77,11 @@ __win_if_tx(struct vr_interface *vif, struct vr_packet *pkt)
 
     NDIS_SWITCH_PORT_DESTINATION newDestination = { 0 };
 
+    if (pkt->vp_win_data > 0) {
+        NdisAdvanceNetBufferListDataStart(nbl, pkt->vp_win_data, FALSE, NULL);
+        pkt->vp_win_data = 0;
+    }
+
     newDestination.PortId = vif->vif_port;
     newDestination.NicIndex = vif->vif_nic;
     DbgPrint("Adding target, PID: %u, NID: %u\r\n", newDestination.PortId, newDestination.NicIndex);

--- a/windows/vr_pkt0.c
+++ b/windows/vr_pkt0.c
@@ -287,7 +287,7 @@ pkt0_if_tx(struct vr_interface *vif, struct vr_packet *vrp)
     KeReleaseSpinLock(&ctx->lock, old_irql);
 
     /* vr_packet is no longer needed, drop it without updating statistics */
-    win_pfree_unaccounted(vrp);
+    win_free_packet(vrp);
 
     return 0;
 }


### PR DESCRIPTION
Remarks:
* `win_get_packet()` function was moved up in `vr_host.c`, so it is defined alongisde other packet/NBL manipulation functions.