### PR TITLE
JW-939: KSync agent porting

### DIFF
--- a/dp-core/vrouter.c
+++ b/dp-core/vrouter.c
@@ -471,8 +471,13 @@ vrouter_exit(bool soft_reset)
     }
 
     /* This is necessary on operating systems that don't
-     * unload the binary on exit*/
-    memset(&router, 0, sizeof(router));
+     * unload the binary on exit.
+     * When soft reset is happening we must not reinitialize
+     * vrouter struct.
+     */
+    if (!soft_reset) {
+        memset(&router, 0, sizeof(router));
+    }
 
     return;
 }

--- a/utils/SConscript
+++ b/utils/SConscript
@@ -16,9 +16,7 @@ if system_header_path:
     env.Append(CPPPATH = system_header_path + '/include/')
 
 # CFLAGS
-if sys.platform.startswith('win'):
-    env.Append(CCFLAGS = ['/D_UNICODE', '/DUNICODE'])
-else:
+if not sys.platform.startswith('win'):
     env.Append(CCFLAGS = '-g')
 
 if 'install' in COMMAND_LINE_TARGETS:

--- a/utils/flow.c
+++ b/utils/flow.c
@@ -32,7 +32,7 @@
 #include <nl_util.h>
 #include "vr_ksync_defs.h"
 
-char* ether_ntoa(unsigned char* etheraddr);
+char* ether_ntoa(const struct ether_addr *addr);
 int gettimeofday(struct timeval * tp, struct timezone * tzp);
 #define CLEAN_SCREEN            "cls"
 #else
@@ -1675,7 +1675,7 @@ flow_table_map(vr_flow_req *req)
 #if defined(_WINDOWS)
 
         struct mem_wrapper sharedMem;
-        LPDWORD bRetur;
+        DWORD bRetur;
 
         HANDLE hPipe = CreateFile(KSYNC_PATH,
 

--- a/utils/vr_win_util.c
+++ b/utils/vr_win_util.c
@@ -52,7 +52,7 @@ print_and_get_error_code()
     DWORD ret = FormatMessage(flags, NULL, error, lang_id, message, 0, NULL);
 
     if (ret != 0) {
-        printf("Error: %ws [%d]\r\n", message, error);
+        printf("Error: %s [%d]\r\n", message, error);
         LocalFree(message);
     } else {
         printf("Error: [%d]\r\n", error);

--- a/windows/vr_ksync.c
+++ b/windows/vr_ksync.c
@@ -184,6 +184,7 @@ KsyncDispatchWrite(PDEVICE_OBJECT DriverObject, PIRP Irp)
             goto failure;
 
         ksync_response->header.type = KSYNC_RESPONSE_DONE;
+        ksync_response->header.seq = msg_seq;
         ksync_response->header.len = 0;
 
         KsyncAppendResponse(ctx, ksync_response);


### PR DESCRIPTION
* Adds missing sequence number in `ksync_response_header`

closes JW-939, JW-989