### PR TITLE
WIP: JW-1242: initial cleanup before merge

### DIFF
--- a/dp-core/vr_flow.c
+++ b/dp-core/vr_flow.c
@@ -69,6 +69,11 @@ unsigned int vr_trap_flow(struct vrouter *, struct vr_flow_entry *,
 
 void get_random_bytes(void *buf, int nbytes);
 
+#ifdef __FreeBSD__
+uint32_t
+jhash(void *key, uint32_t length, uint32_t initval);
+#endif
+
 #if defined(__FreeBSD__) || defined(_WIN32)
 uint32_t
 jhash(void *key, uint32_t length, uint32_t initval)

--- a/dp-core/vr_interface.c
+++ b/dp-core/vr_interface.c
@@ -28,8 +28,6 @@ static int vif_fat_flow_add(struct vr_interface *, vr_interface_req *);
 static bool vif_fat_flow_port_is_set(struct vr_interface *, uint8_t,
                 uint16_t);
 
-void vif_attach(struct vr_interface *);
-void vif_detach(struct vr_interface *);
 int vr_gro_vif_add(struct vrouter *, unsigned int, char *, unsigned short);
 struct vr_interface_stats *vif_get_stats(struct vr_interface *, unsigned short);
 struct vr_interface *__vrouter_get_interface_os(struct vrouter *, unsigned int);

--- a/dp-core/vr_route.c
+++ b/dp-core/vr_route.c
@@ -63,7 +63,6 @@ static struct rtable_fspec rtable_families[] = {
     }
 };
 
-
 static struct rtable_fspec *
 vr_get_family(unsigned int family)
 {
@@ -78,6 +77,8 @@ vr_get_family(unsigned int family)
     default:
         return NULL;
     }
+
+    return NULL;
 }
 
 int

--- a/dp-core/vrouter.c
+++ b/dp-core/vrouter.c
@@ -102,6 +102,7 @@ static struct vr_module modules[] = {
         .exit           =       vr_qos_exit,
     },
 
+
 };
 
 
@@ -120,8 +121,8 @@ int vr_perfs = 1;    /* segmentation in software */
 int vr_perfr = 0;    /* GRO */
 int vr_perfs = 0;    /* segmentation in software */
 #elif defined(_WIN32)
-int vr_perfr = 0;
-int vr_perfs = 0;
+int vr_perfr = 0;    /* GRO */
+int vr_perfs = 0;    /* segmentation in software */
 #endif
 
 /*
@@ -139,8 +140,8 @@ int vr_to_vm_mss_adj = 1;   /* adjust TCP MSS on packet sent to VM */
 int vr_from_vm_mss_adj = 0; /* adjust TCP MSS on packets from VM */
 int vr_to_vm_mss_adj = 0;   /* adjust TCP MSS on packet sent to VM */
 #elif defined(_WIN32)
-int vr_from_vm_mss_adj = 0;
-int vr_to_vm_mss_adj = 0;
+int vr_from_vm_mss_adj = 0; /* adjust TCP MSS on packets from VM */
+int vr_to_vm_mss_adj = 0;   /* adjust TCP MSS on packet sent to VM */
 #endif
 /*
  * Following sysctls are to enable RPS. Based on empirical results,

--- a/include/nl_util.h
+++ b/include/nl_util.h
@@ -13,10 +13,6 @@ extern "C" {
 #include "vr_utils.h"
 #include "vr_response.h"
 
-#ifdef _WIN32
-#include "windows_ksync.h"
-#endif
-
 #define NL_RESP_DEFAULT_SIZE        512
 #define NL_MSG_DEFAULT_SIZE         4096
 
@@ -32,8 +28,6 @@ extern "C" {
 #else
 #define CLEAN_SCREEN_CMD        "clear"
 #endif
-
-extern struct nl_sandesh_callbacks nl_cb;
 
 struct nl_response {
     uint8_t *nl_data;
@@ -103,6 +97,8 @@ struct nl_sandesh_callbacks {
     void (*vr_fc_map_req_process)(void *);
     void (*vr_qos_map_req_process)(void *);
 };
+
+extern struct nl_sandesh_callbacks nl_cb;
 
 /* Suppress NetLink error messages */
 extern bool vr_ignore_nl_errors;

--- a/include/vr_btable.h
+++ b/include/vr_btable.h
@@ -6,8 +6,6 @@
 #ifndef __VR_BTABLE_H__
 #define __VR_BTABLE_H__
 
-#include "vr_os.h"
-
 #define VB_FLAG_MEMORY_ATTACHED 0x1
 
 #define VR_SINGLE_ALLOC_LIMIT   (4 * 1024 * 1024)

--- a/include/vr_fragment.h
+++ b/include/vr_fragment.h
@@ -8,8 +8,6 @@
 #define __VR_FRAGMENT_H__
 
 #include "vr_os.h"
-#include "vr_flow.h"
-#include "vr_packet.h"
 
 #define VR_ASSEMBLER_TIMEOUT_TIME               5
 #define VR_LINUX_ASSEMBLER_BUCKETS              1024

--- a/include/vr_ip_mtrie.h
+++ b/include/vr_ip_mtrie.h
@@ -9,9 +9,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "vr_os.h"
-
 struct ip_bucket;
 
 /*

--- a/include/vr_mpls.h
+++ b/include/vr_mpls.h
@@ -6,7 +6,6 @@
 #ifndef __VR_MPLS_H__
 #define __VR_MPLS_H__
 
-#include "vr_os.h"
 #include "vr_types.h"
 
 #define VR_MPLS_LABEL_SHIFT         12

--- a/include/vr_queue.h
+++ b/include/vr_queue.h
@@ -8,6 +8,12 @@
 
 #include "vr_os.h"
 
+#ifndef _WIN32
+#define CONTAINER_OF(member, struct_type, pointer) \
+    ((struct_type *)((unsigned long)pointer - \
+        (size_t)&(((struct_type *)0)->member)))
+#endif
+
 struct vr_qelem {
     struct vr_qelem *q_next;
 };

--- a/include/vrouter.h
+++ b/include/vrouter.h
@@ -124,8 +124,8 @@ extern int hashrnd_inited;
 extern uint32_t vr_hashrnd;
 
 #define CONTAINER_OF(member, struct_type, pointer) \
-    ((struct_type *)((size_t)pointer - \
-                (size_t)&(((struct_type *)0)->member)))
+    ((struct_type *)((uintptr_t)pointer - \
+                (uintptr_t)&(((struct_type *)0)->member)))
 
 
 typedef void(*vr_defer_cb)(struct vrouter *router, void *user_data);

--- a/include/windows_ksync.h
+++ b/include/windows_ksync.h
@@ -6,28 +6,14 @@
 #ifndef __WINDOWS_KSYNC_H__
 #define __WINDOWS_KSYNC_H__
 
-#define NL_RESP_DEFAULT_SIZE        512
-#define NL_MSG_DEFAULT_SIZE         4096
-
-#define NL_MSG_TYPE_ERROR           0
-#define NL_MSG_TYPE_DONE            1
-#define NL_MSG_TYPE_GEN_CTRL        2
-#define NL_MSG_TYPE_FMLY            3
-
-#define VR_NETLINK_PROTO_DEFAULT    0xFFFFFFFF
-
-#define GENL_FAMILY_NAME_LEN            16
-
-#define NLA_DATA(nla)                   ((char *)nla + NLA_HDRLEN)
-#define NLA_LEN(nla)                    (nla->nla_len - NLA_HDRLEN)
-#define GENLMSG_DATA(buf)               ((char *)buf + GENL_HDRLEN)
+#define KSYNC_MAX_BUFFER_SIZE   4096
 
 typedef struct _KSYNC_RESPONSE   KSYNC_RESPONSE;
 typedef struct _KSYNC_RESPONSE *PKSYNC_RESPONSE;
 struct _KSYNC_RESPONSE {
     PKSYNC_RESPONSE next;
     size_t message_len;
-    uint8_t buffer[NL_MSG_DEFAULT_SIZE];
+    uint8_t buffer[KSYNC_MAX_BUFFER_SIZE];
 };
 
 typedef struct _KSYNC_DEVICE_CONTEXT   KSYNC_DEVICE_CONTEXT;
@@ -38,7 +24,7 @@ struct _KSYNC_DEVICE_CONTEXT {
 
     size_t WrittenBytes;
     size_t WriteBufferSize;
-    uint8_t WriteBuffer[NL_MSG_DEFAULT_SIZE];
+    uint8_t WriteBuffer[KSYNC_MAX_BUFFER_SIZE];
 };
 
 #endif /* __WINDOWS_KSYNC_H__ */

--- a/linux/vr_host_interface.c
+++ b/linux/vr_host_interface.c
@@ -41,9 +41,6 @@ extern int vr_gro_vif_add(struct vrouter *, unsigned int, char *, unsigned short
 extern struct vr_interface_stats *vif_get_stats(struct vr_interface *,
         unsigned short);
 
-extern void vif_attach(struct vr_interface *);
-extern void vif_detach(struct vr_interface *);
-
 static int vr_napi_poll(struct napi_struct *, int);
 static rx_handler_result_t pkt_gro_dev_rx_handler(struct sk_buff **);
 static int linux_xmit_segments(struct vr_interface *, struct sk_buff *,


### PR DESCRIPTION
Changes made:

- `dp-core/vr_flow.c`: revert jhash declaration
- `dp-core/vr_route.c`: revert unnecessary deletes
- `dp-core/vrouter.c`: add comments on global config
- `freebsd/vr_bsd_transport.c`: revert `NETLINK_HEADER_LEN`
- `include/nl_util.h`: remove unnecessary include of windows_ksync.h
- `include/vr_btable.h`: remove unnecessary include of `vr_os.h`
- `include/vr_ip_mtrie.h`: unnecessary include
- `include/vr_mpls.h`: unnecessary include
- `include/vr_queue.h`: revert `CONTAINER_OF`