### PR TITLE
JW-1242: refactorings in vr_packet functions in vr_nbl.c

### DIFF
--- a/include/windows_nbl.h
+++ b/include/windows_nbl.h
@@ -24,7 +24,7 @@ extern PNET_BUFFER_LIST CreateNetBufferList(unsigned int bytesCount);
 extern PNET_BUFFER_LIST CloneNetBufferList(PNET_BUFFER_LIST originalNbl);
 extern VOID FreeNetBufferList(PNET_BUFFER_LIST nbl);
 extern VOID FreeCreatedNetBufferList(PNET_BUFFER_LIST nbl);
-extern VOID FreeClonedNetBufferList(PNET_BUFFER_LIST nbl);
+extern LONG FreeClonedNetBufferList(PNET_BUFFER_LIST nbl);
 
 extern struct vr_packet *GetVrPacketFromNetBufferList(PNET_BUFFER_LIST nbl);
 extern void GetVrPacketMapFromMdl(struct vr_packet *pkt, PMDL mdl, ULONG mdl_offset, ULONG data_length);

--- a/include/windows_nbl.h
+++ b/include/windows_nbl.h
@@ -27,7 +27,7 @@ extern VOID FreeCreatedNetBufferList(PNET_BUFFER_LIST nbl);
 extern VOID FreeClonedNetBufferList(PNET_BUFFER_LIST nbl);
 
 extern struct vr_packet *GetVrPacketFromNetBufferList(PNET_BUFFER_LIST nbl);
-extern void win_packet_map_from_mdl(struct vr_packet *pkt, PMDL mdl, ULONG mdl_offset, ULONG data_length);
+extern void GetVrPacketMapFromMdl(struct vr_packet *pkt, PMDL mdl, ULONG mdl_offset, ULONG data_length);
 extern struct vr_packet *AllocateVrPacketForNetBufferList(PNET_BUFFER_LIST nbl, struct vr_interface *vif);
 extern struct vr_packet *AllocateVrPacket(void *buffer, unsigned int size);
 extern void FreeVrPacket(struct vr_packet *pkt);

--- a/include/windows_nbl.h
+++ b/include/windows_nbl.h
@@ -26,9 +26,10 @@ extern VOID FreeNetBufferList(PNET_BUFFER_LIST nbl);
 extern VOID FreeCreatedNetBufferList(PNET_BUFFER_LIST nbl);
 extern VOID FreeClonedNetBufferList(PNET_BUFFER_LIST nbl);
 
-extern struct vr_packet *win_get_packet(PNET_BUFFER_LIST nbl, struct vr_interface *vif);
+extern struct vr_packet *GetVrPacketFromNetBufferList(PNET_BUFFER_LIST nbl);
 extern void win_packet_map_from_mdl(struct vr_packet *pkt, PMDL mdl, ULONG mdl_offset, ULONG data_length);
-extern struct vr_packet *win_allocate_packet(void *buffer, unsigned int size);
-extern void win_free_packet(struct vr_packet *pkt);
+extern struct vr_packet *AllocateVrPacketForNetBufferList(PNET_BUFFER_LIST nbl, struct vr_interface *vif);
+extern struct vr_packet *AllocateVrPacket(void *buffer, unsigned int size);
+extern void FreeVrPacket(struct vr_packet *pkt);
 
 #endif /* __WINDOWS_NBL_H__ */

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -236,6 +236,7 @@ win_pexpand_head(struct vr_packet *originalPacket, unsigned int headSpace)
 
 cleanupContext:
     NdisFreeNetBufferListContext(newNbl, VR_NBL_CONTEXT_SIZE);
+    vr_sync_sub_and_fetch_32u(&originalPacket->vp_ref_cnt, 1);
 
 cleanup:
     FreeClonedNetBufferList(newNbl);
@@ -297,6 +298,7 @@ win_pclone(struct vr_packet *originalPacket)
 
 cleanupPacket:
     NdisFreeNetBufferListContext(newNbl, VR_NBL_CONTEXT_SIZE);
+    vr_sync_sub_and_fetch_32u(&originalPacket->vp_ref_cnt, 1);
 
 cleanupNbl:
     FreeClonedNetBufferList(newNbl);

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -125,7 +125,7 @@ win_page_free(void *address, unsigned int size)
 static struct vr_packet *
 win_palloc(unsigned int size)
 {
-    return win_allocate_packet(NULL, size);
+    return AllocateVrPacket(NULL, size);
 }
 
 static void
@@ -139,7 +139,7 @@ win_pfree(struct vr_packet *pkt, unsigned short reason)
     if (router)
         ((uint64_t *)(router->vr_pdrop_stats[cpu]))[reason]++;
 
-    win_free_packet(pkt);
+    FreeVrPacket(pkt);
 }
 
 static struct vr_packet *
@@ -156,7 +156,7 @@ win_palloc_head(struct vr_packet *pkt, unsigned int size)
     if (nb_head == NULL)
         return NULL;
 
-    struct vr_packet* npkt = win_get_packet(nb_head, pkt->vp_if);
+    struct vr_packet* npkt = AllocateVrPacketForNetBufferList(nb_head, pkt->vp_if);
     if (npkt == NULL)
     {
         FreeCreatedNetBufferList(nb_head);

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -187,7 +187,7 @@ win_pexpand_head(struct vr_packet *originalPacket, unsigned int headSpace)
     struct vr_packet* newPacket = GetVrPacketFromNetBufferList(newNbl);
     ASSERT(newPacket != NULL);
 
-    RtlCopyMemory(newPacket, originalPacket, sizeof(*originalPacket));
+    *newPacket = *originalPacket;
     newPacket->vp_cpu = (unsigned char)KeGetCurrentProcessorNumberEx(NULL);
     newPacket->vp_ref_cnt = 1;
     newPacket->vp_net_buffer_list = newNbl;

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -908,7 +908,6 @@ static unsigned int
 win_get_log_level(void)
 {
     // TODO(Windows): Implement
-    ASSERTMSG("Not implemented", FALSE);
 
     return 0;
 }
@@ -917,8 +916,8 @@ static unsigned int *
 win_get_enabled_log_types(int *size)
 {
     // TODO(Windows): Implement
-    ASSERTMSG("Not implemented", FALSE);
 
+    *size = 0;
     return NULL;
 }
 

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -965,14 +965,18 @@ UpdateVifToPortMapping(struct vr_interface *vif, vr_interface_req *vifr, PNDIS_S
         }  else if (element->NicType == NdisSwitchNicTypeEmulated || element->NicType == NdisSwitchNicTypeSynthetic) {
             ANSI_STRING ansiName;
             ansiName.Buffer = vifr->vifr_if_guid;
-            ansiName.Length = vifr->vifr_if_guid_size + 1; // For NULL character
-            ansiName.MaximumLength = vifr->vifr_if_guid_size + 1; // For NULL character
+            ansiName.Length = vifr->vifr_if_guid_size;
+            ansiName.MaximumLength = vifr->vifr_if_guid_size;
 
             UNICODE_STRING unicodeName;
             RtlAnsiStringToUnicodeString(&unicodeName, &ansiName, TRUE);
-            ULONG length = (element->NicName.Length < unicodeName.Length ? element->NicName.Length : unicodeName.Length);
 
-            if (memcmp(unicodeName.Buffer, element->NicName.String, length) == 0) {
+            UNICODE_STRING nicName;
+            nicName.Buffer = element->NicName.String;
+            nicName.Length = element->NicName.Length;
+            nicName.MaximumLength = element->NicName.Length;
+
+            if (RtlCompareUnicodeString(&nicName, &unicodeName, FALSE) == 0) {
                 vif->vif_port = element->PortId;
                 vif->vif_nic = element->NicIndex;
                 RtlFreeUnicodeString(&unicodeName);

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -231,6 +231,9 @@ win_pexpand_head(struct vr_packet *originalPacket, unsigned int headSpace)
     newPacket->vp_network_h += (unsigned short)headSpace;
     newPacket->vp_inner_network_h += (unsigned short)headSpace;
 
+    // Mark the original packet as garbage, so it will be cleaned recursively.
+    originalPacket->vp_net_buffer_list = NULL;
+
     return newPacket;
 
 cleanupContext:

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -24,9 +24,6 @@ struct scheduled_work_cb_data {
 
 NDIS_IO_WORKITEM_FUNCTION deferred_work_routine;
 
-static unsigned int win_get_cpu(void);
-static void win_pfree(struct vr_packet *pkt, unsigned short reason);  // Forward declaration
-
 static int
 win_printf(const char *format, ...)
 {
@@ -44,11 +41,11 @@ win_printf(const char *format, ...)
 static void *
 win_malloc(unsigned int size, unsigned int object)
 {
-    UNREFERENCED_PARAMETER(object);
+    void *mem = ExAllocatePoolWithTag(NonPagedPoolNx, size, VrAllocationTag);
+    if (mem == NULL)
+        return NULL;
 
-    void *mem = ExAllocatePoolWithTag(NonPagedPoolNx, size, VrAllocationTag); // TODO: Check with paged pool
-
-    //vr_malloc_stats(size, object);
+    vr_malloc_stats(size, object);
 
     return mem;
 }
@@ -56,16 +53,13 @@ win_malloc(unsigned int size, unsigned int object)
 static void *
 win_zalloc(unsigned int size, unsigned int object)
 {
-    UNREFERENCED_PARAMETER(object);
-
     ASSERT(size > 0);
 
-    void *mem = ExAllocatePoolWithTag(NonPagedPoolNx, size, VrAllocationTag); // TODO: Check with paged pool
-    if (!mem)
+    void *mem = ExAllocatePoolWithTag(NonPagedPoolNx, size, VrAllocationTag);
+    if (mem == NULL)
         return NULL;
 
     NdisZeroMemory(mem, size);
-
     vr_malloc_stats(size, object);
 
     return mem;
@@ -77,7 +71,7 @@ win_page_alloc(unsigned int size)
     ASSERT(size > 0);
 
     void *mem = ExAllocatePoolWithTag(PagedPool, size, VrAllocationTag);
-    if (!mem)
+    if (mem == NULL)
         return NULL;
 
     NdisZeroMemory(mem, size);
@@ -90,9 +84,7 @@ win_free(void *mem, unsigned int object)
 {
     ASSERT(mem != NULL);
 
-    UNREFERENCED_PARAMETER(object);
-
-    if (mem) {
+    if (mem != NULL) {
         vr_free_stats(object);
         ExFreePool(mem);
     }
@@ -174,65 +166,79 @@ win_palloc_head(struct vr_packet *pkt, unsigned int size)
 }
 
 static struct vr_packet *
-win_pexpand_head(struct vr_packet *pkt, unsigned int hspace)
+win_pexpand_head(struct vr_packet *originalPacket, unsigned int headSpace)
 {
-    ASSERT(pkt != NULL);
+    /*
+        Expanding head space is implemented as NDIS retreat operation on the cloned packet.
+    */
 
-    PNET_BUFFER_LIST original_nbl = pkt->vp_net_buffer_list;
-    if (original_nbl == NULL)
+    ASSERT(originalPacket != NULL);
+    ASSERT(originalPacket->vp_net_buffer_list != NULL);
+
+    PNET_BUFFER_LIST originalNbl = originalPacket->vp_net_buffer_list;
+    PNET_BUFFER_LIST newNbl = CloneNetBufferList(originalNbl);
+    if (newNbl == NULL)
         return NULL;
 
-    PNET_BUFFER_LIST new_nbl = CloneNetBufferList(original_nbl);
-    if (new_nbl == NULL)
+    NDIS_STATUS status = NdisAllocateNetBufferListContext(newNbl, VR_NBL_CONTEXT_SIZE, 0, VrAllocationTag);
+    if (status != NDIS_STATUS_SUCCESS)
         goto cleanup;
 
-    NdisAllocateNetBufferListContext(new_nbl, VR_NBL_CONTEXT_SIZE, 0, VrAllocationTag);
-    struct vr_packet* npkt = (struct vr_packet*) NET_BUFFER_LIST_CONTEXT_DATA_START(new_nbl);
-    *npkt = *pkt;
-    pkt = npkt;
-    pkt->vp_ref_cnt = 1;
+    struct vr_packet* newPacket = GetVrPacketFromNetBufferList(newNbl);
+    ASSERT(newPacket != NULL);
 
-    pkt->vp_net_buffer_list = new_nbl;
-    // pkt->vp_ref_cnt is increased because new data is referencing this packet, but also decreased because we don't keep the parent any longer (logically)
+    RtlCopyMemory(newPacket, originalPacket, sizeof(*originalPacket));
+    newPacket->vp_cpu = (unsigned char)KeGetCurrentProcessorNumberEx(NULL);
+    newPacket->vp_ref_cnt = 1;
+    newPacket->vp_net_buffer_list = newNbl;
+    vr_sync_add_and_fetch_32u(&originalPacket->vp_ref_cnt, 1);
 
-    PNET_BUFFER nb = NET_BUFFER_LIST_FIRST_NB(new_nbl);
-    if (nb == NULL)
-        goto cleanup;
+    PNET_BUFFER newNb = NET_BUFFER_LIST_FIRST_NB(newNbl);
+    ASSERT(newNb != NULL);
 
-    if (nb->CurrentMdlOffset >= hspace) {
-        if (NdisRetreatNetBufferDataStart(nb, hspace, 0, NULL) != NDIS_STATUS_SUCCESS)
-            goto cleanup;
+    if (newNb->CurrentMdlOffset >= headSpace) {
+        if (NdisRetreatNetBufferDataStart(newNb, headSpace, 0, NULL) != NDIS_STATUS_SUCCESS)
+            goto cleanupContext;
+    } else {
+        ULONG length = 0;
+        PVOID previousBuffer = NULL;
+        NdisQueryMdl(newNb->CurrentMdl, &previousBuffer, &length, LowPagePriority);
+
+        ULONG dataOffset = newNb->CurrentMdlOffset;
+        ULONG dataSize = length - dataOffset;
+        ULONG requiredSize = dataSize + headSpace;
+        NdisAdvanceNetBufferDataStart(newNb, dataSize, TRUE, NULL);
+        if (NdisRetreatNetBufferDataStart(newNb, requiredSize, 0, NULL) != NDIS_STATUS_SUCCESS)
+            goto cleanupContext;
+
+        PVOID currentBuffer = NULL;
+        NdisQueryMdl(newNb->CurrentMdl, &currentBuffer, &length, LowPagePriority);
+
+        uint8_t *dest = (uint8_t*)currentBuffer + headSpace;
+        uint8_t *src = (uint8_t*)previousBuffer + dataOffset;
+        RtlCopyMemory(dest, src, dataSize);
     }
-    else {
-        UINT mdl_len = 0;
-        PVOID old_buffer = NULL;
-        PVOID new_buffer = NULL;
-        NdisQueryMdl(nb->CurrentMdl, &old_buffer, &mdl_len, LowPagePriority);
-        UINT data_size_in_current_mdl = mdl_len - nb->CurrentMdlOffset;
-        UINT required_continuous_buffer_size = data_size_in_current_mdl + hspace;
-        UINT data_offset = nb->CurrentMdlOffset;
-        NdisAdvanceNetBufferDataStart(nb, data_size_in_current_mdl, TRUE, NULL);
-        if (NdisRetreatNetBufferDataStart(nb, required_continuous_buffer_size, 0, NULL) != NDIS_STATUS_SUCCESS) {
-            goto cleanup;
-        }
-        NdisQueryMdl(nb->CurrentMdl, &new_buffer, &mdl_len, LowPagePriority);
-        RtlCopyMemory((uint8_t*)new_buffer + hspace, (uint8_t*)old_buffer + data_offset, data_size_in_current_mdl);
-    }
 
-    pkt->vp_head =
-        (unsigned char*)MmGetSystemAddressForMdlSafe(nb->CurrentMdl, LowPagePriority | MdlMappingNoExecute) + NET_BUFFER_CURRENT_MDL_OFFSET(nb);
-    pkt->vp_data += (unsigned short)hspace;
-    pkt->vp_tail += (unsigned short)hspace;
-    pkt->vp_end = MmGetMdlByteCount(nb->CurrentMdl);
+    ULONG priorityFlags = LowPagePriority | MdlMappingNoExecute;
+    PCHAR newPacketBuffer = MmGetSystemAddressForMdlSafe(newNb->CurrentMdl, priorityFlags);
+    ULONG newPacketMdlOffset = NET_BUFFER_CURRENT_MDL_OFFSET(newNb);
+    ULONG newPacketMdlCount = MmGetMdlByteCount(newNb->CurrentMdl);
 
-    pkt->vp_network_h += (unsigned short)hspace;
-    pkt->vp_inner_network_h += (unsigned short)hspace;
+    newPacket->vp_head = newPacketBuffer + newPacketMdlOffset;
+    newPacket->vp_data += (unsigned short)headSpace;
+    newPacket->vp_tail += (unsigned short)headSpace;
+    newPacket->vp_end = newPacketMdlCount;
 
-    return pkt;
+    newPacket->vp_network_h += (unsigned short)headSpace;
+    newPacket->vp_inner_network_h += (unsigned short)headSpace;
+
+    return newPacket;
+
+cleanupContext:
+    NdisFreeNetBufferListContext(newNbl, VR_NBL_CONTEXT_SIZE);
 
 cleanup:
-    if (new_nbl)
-        FreeClonedNetBufferList(new_nbl);
+    FreeClonedNetBufferList(newNbl);
 
     return NULL;
 }
@@ -259,47 +265,41 @@ win_preset(struct vr_packet *pkt)
 }
 
 static struct vr_packet *
-win_pclone(struct vr_packet *pkt)
+win_pclone(struct vr_packet *originalPacket)
 {
-    ASSERT(pkt != NULL);
+    ASSERT(originalPacket != NULL);
+    ASSERT(originalPacket->vp_net_buffer_list != NULL);
 
-    PNET_BUFFER_LIST original_nbl = pkt->vp_net_buffer_list;
-
-    ASSERT(original_nbl != NULL);
-
-    PNET_BUFFER_LIST nbl = CloneNetBufferList(original_nbl);
-    if (nbl == NULL)
+    PNET_BUFFER_LIST originalNbl = originalPacket->vp_net_buffer_list;
+    PNET_BUFFER_LIST newNbl = CloneNetBufferList(originalNbl);
+    if (newNbl == NULL)
         return NULL;
 
-    NdisAllocateNetBufferListContext(nbl, VR_NBL_CONTEXT_SIZE, 0, VrAllocationTag);
-    struct vr_packet *npkt = (struct vr_packet*) NET_BUFFER_LIST_CONTEXT_DATA_START(nbl);
-    if (npkt == NULL)
-        goto cleanup_nbl;
-    *npkt = *pkt;
+    NDIS_STATUS status = NdisAllocateNetBufferListContext(newNbl, VR_NBL_CONTEXT_SIZE, 0, VrAllocationTag);
+    if (status != NDIS_STATUS_SUCCESS)
+        goto cleanupNbl;
 
-    vr_sync_add_and_fetch_32u(&pkt->vp_ref_cnt, 1);
-    npkt->vp_ref_cnt = 1;
+    struct vr_packet *newPacket = GetVrPacketFromNetBufferList(newNbl);
+    ASSERT(newPacket != NULL);
 
-    npkt->vp_net_buffer_list = nbl;
-
-    npkt->vp_cpu = (unsigned char)win_get_cpu();
+    RtlCopyMemory(newPacket, originalPacket, sizeof(*originalPacket));
+    newPacket->vp_cpu = (unsigned char)KeGetCurrentProcessorNumberEx(NULL);
+    newPacket->vp_ref_cnt = 1;
+    newPacket->vp_net_buffer_list = newNbl;
+    vr_sync_add_and_fetch_32u(&originalPacket->vp_ref_cnt, 1);
 
     NDIS_STATUS copy_status = VrSwitchObject->NdisSwitchHandlers.CopyNetBufferListInfo(
-        VrSwitchObject->NdisSwitchContext,
-        nbl,
-        original_nbl,
-        0);
-
+        VrSwitchObject->NdisSwitchContext, newNbl, originalNbl, 0);
     if (copy_status != NDIS_STATUS_SUCCESS)
-        goto cleanup_pkt;
+        goto cleanupPacket;
 
-    return npkt;
+    return newPacket;
 
-cleanup_pkt:
-    NdisFreeNetBufferListContext(nbl, VR_NBL_CONTEXT_SIZE);
+cleanupPacket:
+    NdisFreeNetBufferListContext(newNbl, VR_NBL_CONTEXT_SIZE);
 
-cleanup_nbl:
-    FreeClonedNetBufferList(nbl);
+cleanupNbl:
+    FreeClonedNetBufferList(newNbl);
 
     return NULL;
 }
@@ -763,7 +763,8 @@ win_pull_inner_headers(struct vr_packet *pkt,
     UNREFERENCED_PARAMETER(reason);
     UNREFERENCED_PARAMETER(tunnel_type_cb);
 
-    //TODO: Implement
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
 
     return 1;
 }
@@ -774,7 +775,9 @@ win_pcow(struct vr_packet *pkt, unsigned short head_room)
     UNREFERENCED_PARAMETER(pkt);
     UNREFERENCED_PARAMETER(head_room);
 
-    /* Dummy implementation */
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
+
     return 0;
 }
 
@@ -789,7 +792,9 @@ win_pull_inner_headers_fast(struct vr_packet *pkt, unsigned char proto,
     UNREFERENCED_PARAMETER(ret);
     UNREFERENCED_PARAMETER(encap_type);
 
-    /* Dummy implementation */
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
+
     return 0;
 }
 
@@ -837,7 +842,9 @@ win_pkt_from_vm_tcp_mss_adj(struct vr_packet *pkt, unsigned short overlay_len)
     UNREFERENCED_PARAMETER(pkt);
     UNREFERENCED_PARAMETER(overlay_len);
 
-    /* Dummy implementation */
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
+
     return 0;
 }
 
@@ -847,7 +854,9 @@ win_pkt_may_pull(struct vr_packet *pkt, unsigned int len)
     UNREFERENCED_PARAMETER(pkt);
     UNREFERENCED_PARAMETER(len);
 
-    /* Dummy implementation */
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
+
     return 0;
 }
 
@@ -858,7 +867,9 @@ win_gro_process(struct vr_packet *pkt, struct vr_interface *vif, bool l2_pkt)
     UNREFERENCED_PARAMETER(vif);
     UNREFERENCED_PARAMETER(l2_pkt);
 
-    /* Dummy implementation */
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
+
     return 0;
 }
 
@@ -870,7 +881,9 @@ win_enqueue_to_assembler(struct vrouter *router, struct vr_packet *pkt,
     UNREFERENCED_PARAMETER(pkt);
     UNREFERENCED_PARAMETER(fmd);
 
-    /* Dummy implementation */
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
+
     return 0;
 }
 
@@ -878,7 +891,9 @@ static void
 win_set_log_level(unsigned int log_level)
 {
     UNREFERENCED_PARAMETER(log_level);
-    return;
+
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
 }
 
 static void
@@ -886,21 +901,26 @@ win_set_log_type(unsigned int log_type, int enable)
 {
     UNREFERENCED_PARAMETER(log_type);
     UNREFERENCED_PARAMETER(enable);
-    return;
+
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
 }
 
 static unsigned int
 win_get_log_level(void)
 {
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
+
     return 0;
 }
 
 static unsigned int *
 win_get_enabled_log_types(int *size)
 {
-    UNREFERENCED_PARAMETER(size);
+    // TODO(Windows): Implement
+    ASSERTMSG("Not implemented", FALSE);
 
-    size = 0;
     return NULL;
 }
 
@@ -920,46 +940,45 @@ win_soft_reset(struct vrouter *router)
     return;
 }
 
-static void
-win_update_vif_port(struct vr_interface *vif, vr_interface_req *vifr, PNDIS_SWITCH_NIC_ARRAY array)
+static BOOLEAN
+CompareInterfacesGuid(GUID *nicGuid, int8_t *vifGuid)
 {
-    for (unsigned int i = 0; i < array->NumElements; i++){
+    return memcmp(nicGuid, vifGuid, sizeof(*nicGuid)) == 0;
+}
+
+static void
+UpdateVifToPortMapping(struct vr_interface *vif, vr_interface_req *vifr, PNDIS_SWITCH_NIC_ARRAY array)
+{
+    for (unsigned int i = 0; i < array->NumElements; i++) {
         PNDIS_SWITCH_NIC_PARAMETERS element = NDIS_SWITCH_NIC_AT_ARRAY_INDEX(array, i);
 
         // "Fake" interface pointing to the default interface, it's not needed.
         if (element->NicType == NdisSwitchNicTypeExternal && element->NicIndex == 0)
             continue;
 
-        if (element->NicType == NdisSwitchNicTypeExternal || element->NicType == NdisSwitchNicTypeInternal)
-        {
-            if (memcmp(&element->NetCfgInstanceId, vifr->vifr_if_guid, sizeof(element->NetCfgInstanceId)) == 0)
-            {
+        if (element->NicType == NdisSwitchNicTypeExternal || element->NicType == NdisSwitchNicTypeInternal) {
+            if (CompareInterfacesGuid(&element->NetCfgInstanceId, vifr->vifr_if_guid)) {
                 vif->vif_port = element->PortId;
                 vif->vif_nic = element->NicIndex;
-
-                break;
+                return;
             }
-        }
-        else if (element->NicType == NdisSwitchNicTypeEmulated || element->NicType == NdisSwitchNicTypeSynthetic)
-        {
-            ANSI_STRING ansi_name;
-            ansi_name.Buffer = vifr->vifr_if_guid;
-            ansi_name.Length = vifr->vifr_if_guid_size + 1; // For NULL character
-            ansi_name.MaximumLength = vifr->vifr_if_guid_size + 1; // For NULL character
+        }  else if (element->NicType == NdisSwitchNicTypeEmulated || element->NicType == NdisSwitchNicTypeSynthetic) {
+            ANSI_STRING ansiName;
+            ansiName.Buffer = vifr->vifr_if_guid;
+            ansiName.Length = vifr->vifr_if_guid_size + 1; // For NULL character
+            ansiName.MaximumLength = vifr->vifr_if_guid_size + 1; // For NULL character
 
-            UNICODE_STRING unicode_name;
-            RtlAnsiStringToUnicodeString(&unicode_name, &ansi_name, TRUE);
+            UNICODE_STRING unicodeName;
+            RtlAnsiStringToUnicodeString(&unicodeName, &ansiName, TRUE);
+            ULONG length = (element->NicName.Length < unicodeName.Length ? element->NicName.Length : unicodeName.Length);
 
-            if (memcmp(unicode_name.Buffer, element->NicName.String, (element->NicName.Length < unicode_name.Length ? element->NicName.Length : unicode_name.Length)) == 0)
-            {
+            if (memcmp(unicodeName.Buffer, element->NicName.String, length) == 0) {
                 vif->vif_port = element->PortId;
                 vif->vif_nic = element->NicIndex;
-
-                RtlFreeUnicodeString(&unicode_name);
-
-                break;
+                RtlFreeUnicodeString(&unicodeName);
+                return;
             } else {
-                RtlFreeUnicodeString(&unicode_name);
+                RtlFreeUnicodeString(&unicodeName);
             }
         }
     }
@@ -981,7 +1000,7 @@ win_register_nic(struct vr_interface* vif, vr_interface_req* vifr)
     }
 
     win_if_lock();
-    win_update_vif_port(vif, vifr, array);
+    UpdateVifToPortMapping(vif, vifr, array);
     win_if_unlock();
 
     VrFreeNicArray(array);

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -191,7 +191,6 @@ win_pexpand_head(struct vr_packet *originalPacket, unsigned int headSpace)
     newPacket->vp_cpu = (unsigned char)KeGetCurrentProcessorNumberEx(NULL);
     newPacket->vp_ref_cnt = 1;
     newPacket->vp_net_buffer_list = newNbl;
-    vr_sync_add_and_fetch_32u(&originalPacket->vp_ref_cnt, 1);
 
     PNET_BUFFER newNb = NET_BUFFER_LIST_FIRST_NB(newNbl);
     ASSERT(newNb != NULL);
@@ -236,7 +235,6 @@ win_pexpand_head(struct vr_packet *originalPacket, unsigned int headSpace)
 
 cleanupContext:
     NdisFreeNetBufferListContext(newNbl, VR_NBL_CONTEXT_SIZE);
-    vr_sync_sub_and_fetch_32u(&originalPacket->vp_ref_cnt, 1);
 
 cleanup:
     FreeClonedNetBufferList(newNbl);
@@ -287,7 +285,6 @@ win_pclone(struct vr_packet *originalPacket)
     newPacket->vp_cpu = (unsigned char)KeGetCurrentProcessorNumberEx(NULL);
     newPacket->vp_ref_cnt = 1;
     newPacket->vp_net_buffer_list = newNbl;
-    vr_sync_add_and_fetch_32u(&originalPacket->vp_ref_cnt, 1);
 
     NDIS_STATUS copy_status = VrSwitchObject->NdisSwitchHandlers.CopyNetBufferListInfo(
         VrSwitchObject->NdisSwitchContext, newNbl, originalNbl, 0);
@@ -298,7 +295,6 @@ win_pclone(struct vr_packet *originalPacket)
 
 cleanupPacket:
     NdisFreeNetBufferListContext(newNbl, VR_NBL_CONTEXT_SIZE);
-    vr_sync_sub_and_fetch_32u(&originalPacket->vp_ref_cnt, 1);
 
 cleanupNbl:
     FreeClonedNetBufferList(newNbl);

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -761,11 +761,11 @@ win_pull_inner_headers(struct vr_packet *pkt,
 {
     UNREFERENCED_PARAMETER(pkt);
     UNREFERENCED_PARAMETER(ip_proto);
-    UNREFERENCED_PARAMETER(reason);
     UNREFERENCED_PARAMETER(tunnel_type_cb);
 
     // TODO(Windows): Implement
-    ASSERTMSG("Not implemented", FALSE);
+    DbgPrint("%s: Unimplemented, calling stub", __func__);
+    *reason = VP_DROP_MISC;
 
     return 1;
 }

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -260,7 +260,7 @@ win_preset(struct vr_packet *pkt)
         return;
     }
 
-    win_packet_map_from_mdl(pkt, NET_BUFFER_CURRENT_MDL(nb),
+    GetVrPacketMapFromMdl(pkt, NET_BUFFER_CURRENT_MDL(nb),
                             NET_BUFFER_CURRENT_MDL_OFFSET(nb), NET_BUFFER_DATA_LENGTH(nb));
 
     return;

--- a/windows/vr_host.c
+++ b/windows/vr_host.c
@@ -774,9 +774,9 @@ win_pcow(struct vr_packet *pkt, unsigned short head_room)
     UNREFERENCED_PARAMETER(head_room);
 
     // TODO(Windows): Implement
-    ASSERTMSG("Not implemented", FALSE);
+    DbgPrint("win_pcow called, returning error\r\n");
 
-    return 0;
+    return 1;
 }
 
 static int

--- a/windows/vr_host_interface.c
+++ b/windows/vr_host_interface.c
@@ -224,12 +224,12 @@ __win_if_tx(struct vr_interface *vif, struct vr_packet *pkt)
 
     NdisAdvanceNetBufferListDataStart(nbl, pkt->vp_data, TRUE, NULL);
 
+    pkt->vp_net_buffer_list = NULL;
+
     NdisFSendNetBufferLists(VrSwitchObject->NdisFilterHandle,
         nbl,
         NDIS_DEFAULT_PORT_NUMBER,
         0);
-
-    pkt->vp_net_buffer_list = NULL;
 
     return 0;
 }

--- a/windows/vr_nbl.c
+++ b/windows/vr_nbl.c
@@ -194,7 +194,7 @@ cleanup:
 }
 
 void
-win_packet_map_from_mdl(struct vr_packet *pkt, PMDL mdl, ULONG mdl_offset, ULONG data_length)
+GetVrPacketMapFromMdl(struct vr_packet *pkt, PMDL mdl, ULONG mdlOffset, ULONG dataLength)
 {
     pkt->vp_head = (unsigned char*) MmGetSystemAddressForMdlSafe(mdl, LowPagePriority | MdlMappingNoExecute);
     if (!pkt->vp_head) {
@@ -202,7 +202,7 @@ win_packet_map_from_mdl(struct vr_packet *pkt, PMDL mdl, ULONG mdl_offset, ULONG
         return;
     }
 
-    pkt->vp_head += mdl_offset;
+    pkt->vp_head += mdlOffset;
     /* vp_data is the offset from vp_head, where packet begins.
        TODO: When packet encapsulation comes into play, then vp_data should differ.
              There should be enough room between vp_head and vp_data to add packet headers.
@@ -210,9 +210,9 @@ win_packet_map_from_mdl(struct vr_packet *pkt, PMDL mdl, ULONG mdl_offset, ULONG
     pkt->vp_data = 0;
 
     // left_mdl_space is a space from begin of data section to the end of mdl
-    ULONG left_mdl_space = MmGetMdlByteCount(mdl) - mdl_offset;
-    pkt->vp_tail = pkt->vp_len = (data_length < left_mdl_space ? data_length : left_mdl_space);
-    pkt->vp_end = left_mdl_space;
+    ULONG leftMdlSpace = MmGetMdlByteCount(mdl) - mdlOffset;
+    pkt->vp_tail = pkt->vp_len = (dataLength < leftMdlSpace ? dataLength : leftMdlSpace);
+    pkt->vp_end = leftMdlSpace;
 
     return;
 }
@@ -243,15 +243,15 @@ AllocateVrPacketForNetBufferList(PNET_BUFFER_LIST nbl, struct vr_interface *vif)
 
     /* vp_head points to the beginning of accesible non-paged memory of the packet */
     PNET_BUFFER nb = NET_BUFFER_LIST_FIRST_NB(nbl);
-    ULONG data_length = NET_BUFFER_DATA_LENGTH(nb);
+    ULONG dataLength = NET_BUFFER_DATA_LENGTH(nb);
 
     if (IS_NBL_OWNED(nbl) && !IS_NBL_CLONE(nbl)) {
-        data_length = 0;
+        dataLength = 0;
     }
 
-    win_packet_map_from_mdl(pkt, NET_BUFFER_CURRENT_MDL(nb),
+    GetVrPacketMapFromMdl(pkt, NET_BUFFER_CURRENT_MDL(nb),
                             NET_BUFFER_CURRENT_MDL_OFFSET(nb),
-                            data_length);
+                            dataLength);
 
     if (!pkt->vp_head) {
         NdisFreeNetBufferListContext(nbl, VR_NBL_CONTEXT_SIZE);

--- a/windows/vr_nbl.c
+++ b/windows/vr_nbl.c
@@ -508,6 +508,15 @@ FilterSendNetBufferListsComplete(
                 DbgPrint("!!! Complete -- packet switched cores: %hhd -> %hhd\r\n", oldCore, thisCore);
             }
 
+            // TODO proper msg
+            ASSERTMSG("Completed NBLS should already be marked as garbage ", pkt->vp_net_buffer_list == NULL);
+
+            if (IS_NBL_OWNED(current) && IS_NBL_CLONE(current)) {
+                PNET_BUFFER_LIST parent = current->ParentNetBufferList;
+                struct vr_packet *parent_pkt = GetVrPacketFromNetBufferList(parent);
+                ASSERTMSG("Completed NBLS' parents should already be marked as garbage ", parent_pkt->vp_net_buffer_list == NULL);
+            }
+
             FreeNetBufferList(current);
         }
     } while (next != NULL);

--- a/windows/vr_nbl.c
+++ b/windows/vr_nbl.c
@@ -502,20 +502,7 @@ FilterSendNetBufferListsComplete(
             DbgPrint("!!! Internal packed found in FilterSendNetBufferListComplete\r\n");
         } else {
             struct vr_packet *pkt = GetVrPacketFromNetBufferList(current);
-            unsigned char thisCore = KeGetCurrentProcessorNumberEx(NULL);
-            unsigned char oldCore = pkt->vp_cpu;
-            if (thisCore != oldCore) {
-                DbgPrint("!!! Complete -- packet switched cores: %hhd -> %hhd\r\n", oldCore, thisCore);
-            }
-
-            // TODO proper msg
             ASSERTMSG("Completed NBLS should already be marked as garbage ", pkt->vp_net_buffer_list == NULL);
-
-            if (IS_NBL_OWNED(current) && IS_NBL_CLONE(current)) {
-                PNET_BUFFER_LIST parent = current->ParentNetBufferList;
-                struct vr_packet *parent_pkt = GetVrPacketFromNetBufferList(parent);
-                ASSERTMSG("Completed NBLS' parents should already be marked as garbage ", parent_pkt->vp_net_buffer_list == NULL);
-            }
 
             FreeNetBufferList(current);
         }

--- a/windows/vr_nbl.c
+++ b/windows/vr_nbl.c
@@ -77,7 +77,7 @@ CreateNetBufferList(unsigned int bytesCount)
     return nbl;
 }
 
-VOID
+LONG
 FreeClonedNetBufferList(PNET_BUFFER_LIST nbl)
 {
     ASSERT(nbl != NULL);
@@ -88,7 +88,7 @@ FreeClonedNetBufferList(PNET_BUFFER_LIST nbl)
     FreeForwardingContext(nbl);
     NdisFreeCloneNetBufferList(nbl, 0);
 
-    InterlockedDecrement(&parentNbl->ChildRefCount);
+    return InterlockedDecrement(&parentNbl->ChildRefCount);
 }
 
 VOID
@@ -150,9 +150,9 @@ FreeNetBufferList(PNET_BUFFER_LIST nbl)
         if (IS_NBL_OWNED(nbl)) {
             if (IS_NBL_CLONE(nbl)) {
                 PNET_BUFFER_LIST parent = nbl->ParentNetBufferList;
-                FreeClonedNetBufferList(nbl);
-
-                FreeNetBufferList(parent);
+                if (FreeClonedNetBufferList(nbl) == 0) {
+                    FreeNetBufferList(parent);
+                }
             } else {
                 FreeCreatedNetBufferList(nbl);
             }

--- a/windows/vr_pkt0.c
+++ b/windows/vr_pkt0.c
@@ -176,7 +176,7 @@ Pkt0DeferredWrite(_In_ PVOID IoObject,
 
     RtlCopyMemory(pkt_data, data, count);
 
-    pkt = win_allocate_packet(pkt_data, count);
+    pkt = AllocateVrPacket(pkt_data, count);
     if (pkt == NULL)
         goto fail;
     pkt->vp_if = agent_if;
@@ -397,7 +397,7 @@ pkt0_if_tx(struct vr_interface *vif, struct vr_packet *vrp)
     }
 
     /* vr_packet is no longer needed, drop it without updating statistics */
-    win_free_packet(vrp);
+    FreeVrPacket(vrp);
 
     return 0;
 }


### PR DESCRIPTION
- `win_get_packet` renamed to `AllocateVrPacketForNetBufferList`
    - also some minor refactorings
- `win_allocate_packet` renamed to `AllocateVrPacket`
- `win_free_packet` renamed to `FreeVrPacket`